### PR TITLE
Add functions to cast unsigned integers to their signed counterparts

### DIFF
--- a/include/kettle/core.h
+++ b/include/kettle/core.h
@@ -84,6 +84,7 @@ static_assert(sizeof(i128) == 16, "Invalid core type size");
 #define I128_MAX ((i128)(((u128)1 << 127) - 1))
 #endif
 
+#include "kettle/core/intcast_fwd.h"
 #include "kettle/core/intcmp_fwd.h"
 
 #endif

--- a/include/kettle/core/intcast_fwd.h
+++ b/include/kettle/core/intcast_fwd.h
@@ -1,0 +1,35 @@
+// RESERVED FOR INTERNAL USE ONLY. Do not include this file directly.
+
+// Casts the provided value to a signed integer of the same size.
+KETTLE_VALUE i8 u8_to_i8(u8 self) {
+    return *(i8 *)&self;
+}
+
+// Casts the provided value to a signed integer of the same size.
+KETTLE_VALUE i16 u16_to_i16(u16 self) {
+    return *(i16 *)&self;
+}
+
+// Casts the provided value to a signed integer of the same size.
+KETTLE_VALUE i32 u32_to_i32(u32 self) {
+    return *(i32 *)&self;
+}
+
+// Casts the provided value to a signed integer of the same size.
+KETTLE_VALUE i64 u64_to_i64(u64 self) {
+    return *(i64 *)&self;
+}
+
+// Casts the provided value to a signed integer of the same size.
+KETTLE_VALUE isize usize_to_isize(usize self) {
+    return *(isize *)&self;
+}
+
+#ifdef KETTLE_HAS_INT128
+
+// Casts the provided value to a signed integer of the same size.
+KETTLE_VALUE i128 u128_to_i128(u128 self) {
+    return *(i128 *)&self;
+}
+
+#endif

--- a/include/kettle/version.h
+++ b/include/kettle/version.h
@@ -4,7 +4,7 @@
 #include "kettle/core/defines.h"
 
 #define KETTLE_VERSION_MAJOR 0
-#define KETTLE_VERSION_MINOR 1
+#define KETTLE_VERSION_MINOR 2
 #define KETTLE_VERSION_PATCH 0
 
 #define KETTLE_VERSION \


### PR DESCRIPTION
Note that we do not require functions to do the opposite, because C casts from signed to unsigned integers do not invoke undefined behavior when wrapping around for negative values.